### PR TITLE
Allow multiple sections with the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ Result:
 </Section>
 ```
 
+If **key** is a *String* and **value** is an *Array* of *Hash* it produces multiple sections with the same name.
+```ruby
+collectd_conf 'string-hash-array' do
+  conf 'Section' => [
+    {'Key1' => 'Value1'},
+    {'Key2' => 'Value2'}
+  ]
+end
+```
+
+Result:
+
+```
+<Section>
+  Key1 "Value1"
+</Section>
+<Section>
+  Key2 "Value2"
+</Section>
+```
+
 If **key** is a *Array* and **value** is a *Hash* it produces section with `key[0]` name and attribute `key[1]`.
 
 ```ruby

--- a/libraries/chef_collectd_config_converter.rb
+++ b/libraries/chef_collectd_config_converter.rb
@@ -65,7 +65,12 @@ module ChefCollectd
           when Array
             # Multiple repeation
             value.each do |subvalue|
-              output << indent_str("#{collectd_key(key)} #{collectd_value(subvalue)}")
+              if subvalue.is_a?(Hash)
+                content = from_hash(subvalue)
+                output << collectd_section(key, content, level)
+              else
+                output << indent_str("#{collectd_key(key)} #{collectd_value(subvalue)}")
+              end
             end
           else
             output << indent_str("#{collectd_key(key)} #{collectd_value(value)}")

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description      'Install and configure the collectd monitoring daemon'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url       'https://github.com/jsirex/collectd-lib-cookbook/issues'
 source_url       'https://github.com/jsirex/collectd-lib-cookbook'
-version          '3.0.2'
+version          '3.1.0'
 
 supports 'debian'
 supports 'ubuntu'


### PR DESCRIPTION
This patch allows multiple sections with the same name like so:

```
             'Value' => [
               {
                 'Type' => 'gauge',
                 'InstancePrefix' => 'loaded_classes',
                 'Table' => false,
                 'Attribute' => 'LoadedClassCount'
               },
               {
                 'Type' => 'counter',
                 'InstancePrefix' => 'write',
                 'Table' => false,
                 'Attribute' => 'WriteOperations'
               }
             ]
```

Closes #1
